### PR TITLE
Expression set default checkbox(1,3,4) to checked

### DIFF
--- a/build/perseus-1.js
+++ b/build/perseus-1.js
@@ -13831,11 +13831,11 @@ var ExpressionEditor = React.createClass({displayName: 'ExpressionEditor',
     getDefaultProps: function() {
         return {
             value: "",
-            form: false,
+            form: true,
             simplify: false,
-            times: false,
+            times: true,
             functions: ["f", "g", "h"],
-            easybuttons: false
+            easybuttons: true
         };
     },
 

--- a/src/widgets/expression.jsx
+++ b/src/widgets/expression.jsx
@@ -252,11 +252,11 @@ var ExpressionEditor = React.createClass({
     getDefaultProps: function() {
         return {
             value: "",
-            form: false,
+            form: true,
             simplify: false,
-            times: false,
+            times: true,
             functions: ["f", "g", "h"],
-            easybuttons: false
+            easybuttons: true
         };
     },
 


### PR DESCRIPTION
Expression/數學式，以下 checkbox 預設打勾:
- 答案一定要與格式相符
- 用 × 表示乘號。
- 小學生專用簡化版選項。

perseus 更新 expression 預設打勾 1, 3, 4

--測試方式--
- 環境：
  local-
  junyiacademy(update_expression)
  jacascript/perseus-package(expression)

test server-
http://43-dot-junyiacademytest1.appspot.com/junyi-middle-school-biology/root/junyi-world-full-of-life/e/life_1
1. 後台測試
   測試頁面路徑 devadmin --> Panel --> 前往題庫系統 --> 用Perseus製作題目
   Question >> 新增一個widget 點選 expression
   新增expresion 展開後的以下預設選項(1,3,4)應該已打勾

[ v] - 答案一定要與格式相符
[ ] - 答案一定要化簡、展開。
[ v] - 用 × 表示乘號
[ v] - 小學生專用簡化版選項
觀察- 答案一定要與格式相符
後台進入編輯
觀察答案一定要與格式相符選項 應該已勾選
編輯正確答案為1+3
存檔後，進入新增題目
後台觀察該題修改，預設勾選應該存在
後台觀察JSON預覽，驗證是否答案3+1 應該顯示正確
後台觀察JSON預覽，驗證是否答案1-(-3) 應該顯示正確
後台觀察JSON預覽，驗證是否答案2+2應該顯示錯誤

觀察 - 用 X 表示乘號
後台編輯＆預覽
觀察用 X 表示乘號 應該勾選
觀察右側框彈出的選項乘號應為 "X"
存檔後，進入新增題目
後台觀察該題預覽 ，輸入格跳出選項乘號應為 “X“
後台觀察該題修改，預設勾選應該存在
後台JSON預覽，expression 乘法選項應為 "X"

觀察 - 小學生專用簡化版選項
後台編輯＆預覽
觀察簡化版選項 應該已勾選
觀察左右側 expression 選項，檢視應為簡化選項（僅加減乘除）
存檔後，重新篩選該題目
後台觀察該題修改，預設勾選應該存在
後台觀察該題JSON預覽 ，輸入格跳出選項應為簡化版選項（僅加減乘除）

2 前台測試
前台進入該題
滑鼠點選expression，觀察彈出選項，跳出選項應為簡化版選項（僅加減乘除）
滑鼠點選expression，觀察彈出選項，乘號是否為 "X" 
點選乘號，觀察是否可正確輸入 "X"
輸入答案，驗證是否答案1+3 應該顯示正確 (預設答案為"1+3")
輸入答案，驗證是否答案3+1 應該顯示正確 (預設答案為"1+3")
輸入答案，驗證是否答案1-(-3) 應該顯示正確 (預設答案為"1+3")
輸入答案，驗證是否答案2+2應該顯示錯誤 (預設答案為"1+3")
