### PR TITLE
讓perseus的帶分數與假分數可互相比較

### DIFF
--- a/lib/kas.js
+++ b/lib/kas.js
@@ -1156,15 +1156,6 @@ _.extend(Expr.prototype, {
     // should only be done after compare() returns true to avoid false positives
     sameForm: function(other) {
         // for fake Rational and mixed number Rational compare
-        if (this instanceof Rational && other instanceof Mul){
-            if(other.isMixedNumberRational()){
-                return true;
-            }
-        }else if(this instanceof Mul && other instanceof Rational){
-            if(this.isMixedNumberRational()){
-                return true;
-            }
-        }
         return this.strip().equals(other.strip());
     },
 

--- a/lib/kas.js
+++ b/lib/kas.js
@@ -979,6 +979,30 @@ _.extend(Expr.prototype, {
         return this.equals(this.simplify());
     },
 
+    isMixedNumberRational: function() {
+        //判斷是否為帶分數
+        if (this.terms.length !== 2){
+            return false;
+        }
+        var left = this.terms[0];
+        var right = this.terms[1];
+        if(left instanceof Int && right instanceof Rational){
+            return true;
+        }else {
+            return false;
+        }
+    },
+
+    getMixedNumberRationalVal: function() {
+        // for mixed number Rational: 1 1/2 = 1+1/2 , -1 1/2 = -1-1/2
+        var left = this.terms[0];
+        var right = this.terms[1];
+        if (left.n < 0){
+            return left.n - right.n/right.d;
+        }
+        return left.n + right.n/right.d;
+    },
+
     // return the child nodes of this node
     exprArgs: function() {
         return _.filter(this.args(), function(arg) {
@@ -1131,6 +1155,16 @@ _.extend(Expr.prototype, {
     // a canonical commutative form
     // should only be done after compare() returns true to avoid false positives
     sameForm: function(other) {
+        // for fake Rational and mixed number Rational compare
+        if (this instanceof Rational && other instanceof Mul){
+            if(other.isMixedNumberRational()){
+                return true;
+            }
+        }else if(this instanceof Mul && other instanceof Rational){
+            if(this.isMixedNumberRational()){
+                return true;
+            }
+        }
         return this.strip().equals(other.strip());
     },
 
@@ -1443,7 +1477,13 @@ _.extend(Mul.prototype, {
     func: Mul,
 
     eval: function(vars) {
-        return _.reduce(this.terms, function(memo, term) { return memo * term.eval(vars); }, 1);
+        if(this.isMixedNumberRational()){
+            return this.getMixedNumberRationalVal();
+        }
+
+        return _.reduce(this.terms, function(memo, term) {
+            return memo * term.eval(vars);
+        }, 1);
     },
 
     print: function() {

--- a/lib/kas.js
+++ b/lib/kas.js
@@ -1155,7 +1155,6 @@ _.extend(Expr.prototype, {
     // a canonical commutative form
     // should only be done after compare() returns true to avoid false positives
     sameForm: function(other) {
-        // for fake Rational and mixed number Rational compare
         return this.strip().equals(other.strip());
     },
 


### PR DESCRIPTION
＃修改目的：
(1)原本帶分數 1又1/2會被認為是1乘1/2 ，當輸入1/2時會被認為正確。
(2)希望帶分數與假分數之間可以互相轉換：1又1/2與 3/2都會正確。

＃修改後：
 (1)當答案為1又1/2，輸入1/2不會正確，輸入1又1/2或者3/2會正確。
 (2)當答案為3/2，與上1.同。

＃如何測試：
(當不勾選答案一定要與格式相符)
(1)正確答案設定1又1/2，輸入1又1/2與 3/2 應該要正確。
(2)正確答案設定3/2，輸入1又1/2與 3/2 應該要正確。
(3)正確答案設定 -1又1/2，輸入-1又1/2與 -3/2 應該要正確。
(4)正確答案設定 -3/2，輸入-1又1/2與 -3/2 應該要正確。
(5)正確答案設定 2x，輸入2x 應該要正確。
(6)正確答案設定 -2x，輸入-2x 應該要正確。
(7)正確答案設定 x/2，輸入x/2 應該要正確。
(8)正確答案設定 -x/2，輸入-x/2 應該要正確。
(9)其餘可以多想些case 測試。
(當勾選答案一定要與格式相符)
(1)設定1又1/2，3/2 應該不正確。 PASS
(2)其他(2)~(4)與(1)同 

＃目前尚未處理的case:
(1)若輸入2x+1又1/2與  2x+3/2目前無法視為相等。
